### PR TITLE
Clean up markdown links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 
 # Vulpes
 
-Vulpes is an implementation of [deep belief] (http://www.cs.toronto.edu/~hinton/absps/fastnc.pdf)  and [deep learning] (http://www.cs.nyu.edu/~yann/research/deep/), written in F# and using [Alea.cuBase] (https://www.quantalea.net/products/introduction/) to connect to your PC's GPU device.
+Vulpes is an implementation of [deep belief](http://www.cs.toronto.edu/~hinton/absps/fastnc.pdf)  and [deep learning](http://www.cs.nyu.edu/~yann/research/deep/), written in F# and using [Alea.cuBase](https://www.quantalea.net/products/introduction/) to connect to your PC's GPU device.
 
 ## Building
 
 At present, Vulpes has been built only on Visual Studio.
 
-To run Vulpes on the [MNIST] (http://yann.lecun.com/exdb/mnist/) dataset of handwritten images, set the startup project to [MnistClassification.fsproj] (https://github.com/SpiegelSoft/Vulpes/blob/master/MnistClassification/MnistClassification.fsproj).
+To run Vulpes on the [MNIST](http://yann.lecun.com/exdb/mnist/) dataset of handwritten images, set the startup project to [MnistClassification.fsproj](https://github.com/SpiegelSoft/Vulpes/blob/master/MnistClassification/MnistClassification.fsproj).
 
 For the MNIST dataset, Vulpes performs pretraining using a deep belief net, followed by fine tuning using a simple backpropagation algorithm.
 
-The pretraining and fine tuning parameters are defined in [Program.fs] (https://github.com/SpiegelSoft/Vulpes/blob/master/MnistClassification/Program.fs):
+The pretraining and fine tuning parameters are defined in [Program.fs](https://github.com/SpiegelSoft/Vulpes/blob/master/MnistClassification/Program.fs):
 
 ```F#
 // Pretraining parameters
@@ -51,9 +51,9 @@ let backPropagationResults = gpuComputeNnetResults backPropagationNetwork mnistT
 
 ## Contributions
 
-There are several avenues for further development of Vulpes.  To contribute as a developer, I would encourage you to join the [mailing list] (https://groups.google.com/forum/#!forum/vulpes-developers), where we can discuss the issues and milestones.
+There are several avenues for further development of Vulpes.  To contribute as a developer, I would encourage you to join the [mailing list](https://groups.google.com/forum/#!forum/vulpes-developers), where we can discuss the issues and milestones.
 
-There is a [list of milestones] (https://github.com/SpiegelSoft/Vulpes/issues/milestones?with_issues=no) and an [issues database] (https://github.com/SpiegelSoft/Vulpes/issues) in this repository.
+There is a [list of milestones](https://github.com/SpiegelSoft/Vulpes/issues/milestones?with_issues=no) and an [issues database](https://github.com/SpiegelSoft/Vulpes/issues) in this repository.
 
 ## Maintainer(s)
 


### PR DESCRIPTION
The links in README.md were not rendering correctly due to a space in between the closing `]` bracket and opening `(`. 

No content has changed in this PR other than removing those spaces so that the links render correctly. 

Thanks for open sourcing this project!